### PR TITLE
Fixed incorrect labels in filesystem_type_widget

### DIFF
--- a/views/filesystem_type_widget.yml
+++ b/views/filesystem_type_widget.yml
@@ -5,6 +5,6 @@ i18n_title: disk_report.filesystem_type
 listing_link: /show/listing/disk_report/disk
 icon: fa-hdd-o
 buttons:
-    - { label: hfs, i18n_label: disk_report.ssd, search_component: hfs, hide_when_zero: true }
-    - { label: apfs, i18n_label: disk_report.fusion, search_component: apfs, hide_when_zero: true }
+    - { label: hfs, i18n_label: HFS+, search_component: hfs, hide_when_zero: true }
+    - { label: apfs, i18n_label: APFS, search_component: apfs, hide_when_zero: true }
     - { label: bootcamp, i18n_label: disk_report.bootcamp, search_component: bootcamp, hide_when_zero: true }

--- a/views/smart_status_widget.yml
+++ b/views/smart_status_widget.yml
@@ -7,4 +7,4 @@ icon: fa-exclamation-circle
 buttons:
     - { label: failing, class: btn-danger, i18n_label: failing, search_component: failing, hide_when_zero: true }
     - { label: verified, class: btn-success, i18n_label: verified, search_component: verified, hide_when_zero: true }
-    - { label: unsupported, class: btn-info, i18n_label: unsuported, search_component: not supported, hide_when_zero: true }
+    - { label: unsupported, class: btn-info, i18n_label: unsupported, search_component: not supported, hide_when_zero: true }


### PR DESCRIPTION
Looks like an uncorrected copy/paste from disk_type_widget. I restored the HFS+ and APFS labels used in the previous PHP widget.