### PR TITLE
Filesystem Type widget label fixes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,5 @@
 {
+    "apfs": "APFS",
     "bootcamp": "BootCamp",
     "bus_protocol": "BUS Protocol",
     "encrypted": "Encrypted",
@@ -8,6 +9,7 @@
     "fusion": "Fusion",
     "global_disk_usage": "Global Disk Usage",
     "hdd": "HDD",
+    "hfs": "HFS+",
     "internal": "Internal",
     "media_type": "Media Type",
     "mountpoint": "Mount Point",

--- a/views/filesystem_type_widget.yml
+++ b/views/filesystem_type_widget.yml
@@ -5,6 +5,6 @@ i18n_title: disk_report.filesystem_type
 listing_link: /show/listing/disk_report/disk
 icon: fa-hdd-o
 buttons:
-    - { label: hfs, i18n_label: HFS+, search_component: hfs, hide_when_zero: true }
-    - { label: apfs, i18n_label: APFS, search_component: apfs, hide_when_zero: true }
+    - { label: hfs, i18n_label: disk_report.hfs, search_component: hfs, hide_when_zero: true }
+    - { label: apfs, i18n_label: disk_report.apfs, search_component: apfs, hide_when_zero: true }
     - { label: bootcamp, i18n_label: disk_report.bootcamp, search_component: bootcamp, hide_when_zero: true }


### PR DESCRIPTION
Matched other yaml widget i18n_label formats for apfs and hfs; added APFS and HFS+ key/value pairs to en.json locale to avoid plural_not_found errors in the widget.
