### PR TITLE
For FileVault 2 Status, update mount point from / to /System/Volumes/Data

### DIFF
--- a/disk_report_controller.php
+++ b/disk_report_controller.php
@@ -39,11 +39,11 @@ class Disk_report_controller extends Module_controller
      * @return void
      * @author
      **/
-    public function get_filevault_stats($mount_point = '/')
+    public function get_filevault_stats($mount_point = '/System/Volumes/Data')
     {
         jsonView(
-            Disk_report_model::selectRaw("COUNT(CASE WHEN encrypted = 1 AND mountpoint = '/' THEN 1 END) AS encrypted")
-                ->selectRaw("COUNT(CASE WHEN encrypted = 0 AND mountpoint = '/' THEN 1 END) AS unencrypted")
+            Disk_report_model::selectRaw("COUNT(CASE WHEN encrypted = 1 AND mountpoint = '/System/Volumes/Data' THEN 1 END) AS encrypted")
+                ->selectRaw("COUNT(CASE WHEN encrypted = 0 AND mountpoint = '/System/Volumes/Data' THEN 1 END) AS unencrypted")
                 ->filter()
                 ->first()
                 ->toLabelCount()


### PR DESCRIPTION
## Reason for PR
[Starting with Catalina](https://support.apple.com/en-us/HT210650) and continuing on to Big Sur (the two most recent macOS releases, with Monterey releasing this fall) encryption is on the `Macintosh HD - Data` partition, which isn't mounted to `/` but to `/System/Volumes/Data`, which causes Macs on the most recent OS versions to report as unencrypted in the disk report instead of as encrypted.

As it is now, the FileVault 2 Status will report incorrectly in a major way for fleets overwhelmingly running the latest two OSes. With this PR, the FileVault 2 Status will report incorrectly in a major way for fleets overwhelmingly running Mojave or older. Ideally, you'd want to cover all cases (see Caveat below), but it's better to err on the side of working for the more recent OS versions.

## Related PR
https://github.com/munkireport/security/pull/21

## Caveat
This is just a "better than what was before" fix instead of a comprehensive one.

## Better
It'd be better to run the queries as
```
SELECT COUNT(CASE WHEN dr.encrypted = 0 AND dr.mountpoint = '/System/Volumes/Data' THEN 1 END) AS unencrypted FROM diskreport dr WHERE dr.serial_number IN (SELECT sdr.serial_number FROM diskreport sdr WHERE sdr.mountpoint = '/System/Volumes/Data')
   UNION
SELECT COUNT(CASE WHEN dr.encrypted = 0 AND dr.mountpoint = '/' THEN 1 END) AS unencrypted FROM diskreport dr WHERE dr.serial_number NOT IN (SELECT sdr.serial_number FROM diskreport sdr WHERE sdr.mountpoint = '/System/Volumes/Data');
```
and
```
SELECT COUNT(CASE WHEN dr.encrypted = 1 AND dr.mountpoint = '/System/Volumes/Data' THEN 1 END) AS encrypted FROM diskreport dr WHERE dr.serial_number IN (SELECT sdr.serial_number FROM diskreport sdr WHERE sdr.mountpoint = '/System/Volumes/Data')
    UNION
SELECT COUNT(CASE WHEN dr.encrypted = 1 AND dr.mountpoint = '/' THEN 1 END) AS encrypted FROM diskreport dr WHERE dr.serial_number NOT IN (SELECT sdr.serial_number FROM diskreport sdr WHERE sdr.mountpoint = '/System/Volumes/Data');
```
but I don't know enough about Lavarel to get those more complex queries to work (I tried `select(` instead of `selectRaw(` to no avail).

### Best
Actually, ideally, you'd want to just run
```
SELECT COUNT(filevault_status = 1) as encrypted FROM filevault_status;
```
and
```
SELECT COUNT(filevault_status = 0) as unencrypted FROM filevault_status;
```
So that FileVault status is tracked in only one place.

## Testing Done
Before PR, for Big Sur client:
![Screen Shot 2021-06-23 at 12 20 44 PM](https://user-images.githubusercontent.com/13055957/123156493-364c2780-d41e-11eb-9534-7175c7779b29.png)

After PR, for Big Sur client:
![Screen Shot 2021-06-23 at 12 20 02 PM](https://user-images.githubusercontent.com/13055957/123156514-3d733580-d41e-11eb-9c8e-e1a3debe4321.png)
