### PR TITLE
Use filevault widget for FV status instead of using disk_report widget for FV status

### DIFF
--- a/disk_report_controller.php
+++ b/disk_report_controller.php
@@ -32,23 +32,6 @@ class Disk_report_controller extends Module_controller
                 ->toArray()
         );
     }
-
-    /**
-     * Get filevault statistics
-     *
-     * @return void
-     * @author
-     **/
-    public function get_filevault_stats($mount_point = '/')
-    {
-        jsonView(
-            Disk_report_model::selectRaw("COUNT(CASE WHEN encrypted = 1 AND mountpoint = '/' THEN 1 END) AS encrypted")
-                ->selectRaw("COUNT(CASE WHEN encrypted = 0 AND mountpoint = '/' THEN 1 END) AS unencrypted")
-                ->filter()
-                ->first()
-                ->toLabelCount()
-        );
-    }
     
      /**
      * Get disk type

--- a/locales/de.json
+++ b/locales/de.json
@@ -22,6 +22,5 @@
   "type": "Massenspeichertyp",
   "used": "Benutzt",
   "volume_type": "Volumetyp",
-  "report": "Disk-Report",
-  "filevault_widget_title": "FileVault 2 Status"
+  "report": "Disk-Report"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,6 +28,5 @@
     "used": "Used",
     "used_disk_space": "Used Disk Space",
     "volume_type": "Volume Type",
-    "report": "Storage Report",
-    "filevault_widget_title": "FileVault 2 Status"
+    "report": "Storage Report"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -22,6 +22,5 @@
     "type": "Type de stockage",
     "used": "Utilisé",
     "volume_type": "Type de Volume",
-    "report": "Stockage",
-    "filevault_widget_title": "État Filevault 2"
+    "report": "Stockage"
 }

--- a/provides.yml
+++ b/provides.yml
@@ -6,7 +6,6 @@ listings:
     disk: { view: disk_listing, i18n: disk_report.storage }
 widgets:
     disk_report: { view: disk_report_widget }
-    filevault: { view: filevault_widget }
     smart_status: { view: smart_status_widget }
     disk_type: { view: disk_type_widget }
     filesystem_type: { view: filesystem_type_widget }

--- a/views/filevault_widget.yml
+++ b/views/filevault_widget.yml
@@ -1,9 +1,0 @@
-type: button
-widget_id: filevault-status-widget
-api_url: /module/disk_report/get_filevault_stats
-i18n_title: disk_report.filevault_widget_title
-listing_link: /show/listing/security/security
-icon: fa-lock
-buttons:
-    - { label: encrypted, class: btn-success, i18n_label: encrypted, search_component: encrypted = 1, hide_when_zero: false }
-    - { label: unencrypted, class: btn-danger, i18n_label: unencrypted, search_component: encrypted = 0, hide_when_zero: false }

--- a/views/storage_report.yml
+++ b/views/storage_report.yml
@@ -1,7 +1,7 @@
 row1:
     disk_report:
     disk_type:
-    filevault:
+    filevault_status:
 row2:
     smart_status:
     filesystem_type:


### PR DESCRIPTION
## Details of PR
- Changes the FileVault status widget from disk_report's own to filevault's
- Removes all other custom FileVault items from within disk_report

### Benefits
- The current disk_report FileVault status widget is broken on Catalina and Big Sur
- Using one widget for FileVault instead of multiple means less to maintain—as long as the filevault module's widget is accurate, it can be accurate in multiple places

## Testing Done
Big Sur encrypted Mac before PR
![Screen Shot 2021-06-25 at 12 28 50 PM](https://user-images.githubusercontent.com/13055957/123477170-852ac600-d5b2-11eb-8236-d10e10726877.png)

Big Sur encrypted Mac after PR
![Screen Shot 2021-06-25 at 12 33 03 PM](https://user-images.githubusercontent.com/13055957/123477188-8bb93d80-d5b2-11eb-83ae-e0efa3241aa7.png)
